### PR TITLE
Feat: Create shareable video 'show' page

### DIFF
--- a/common-util/Contracts/index.jsx
+++ b/common-util/Contracts/index.jsx
@@ -73,11 +73,11 @@ const getWeb3Details = () => {
   return { web3, address, chainId };
 };
 
-export const getBlockchainShortsAddress = () => {
+export const getBlockchainShortsAddress = (id) => {
   const { chainId } = getWeb3Details();
   const url = SCAN_URLS[chainId];
-  const address = ADDRESSES[chainId].blockchainShorts;
-  return `${url}token/${address}`;
+  const address = ADDRESSES[chainId]?.blockchainShorts;
+  return `${url}nft/${address}/${id}`;
 };
 
 const getContract = (abi, contractAddress, web3) => {

--- a/components/Home/VideoCard.jsx
+++ b/components/Home/VideoCard.jsx
@@ -4,6 +4,8 @@ import { Card, Typography } from 'antd';
 import styled from 'styled-components';
 
 import { getBlockchainShortsAddress } from 'common-util/Contracts';
+import { Video } from 'components/Video';
+import Link from 'next/link';
 
 const { Title } = Typography;
 
@@ -23,28 +25,36 @@ const EachVideoContainer = styled.div`
 `;
 
 export const VideoCard = ({ id, videoHash, prompt }) => {
-  const videoUrl = `https://${process.env.NEXT_PUBLIC_REGISTRY_URL}/${videoHash}`;
-  const scanUrl = getBlockchainShortsAddress(id);
+  const explorerUrl = getBlockchainShortsAddress(id);
 
   return (
     <CustomCard>
       <Card.Meta
         title={(
           <EachVideoContainer>
-            <video width="100%" height="100%" controls>
-              <source src={videoUrl} type="video/mp4" />
-              Your browser does not support the video tag.
-            </video>
+            <Video videoHash={videoHash} />
           </EachVideoContainer>
         )}
         description={(
           <>
             <div className="mb-8">
-              <Title level={5} className="mt-0">{prompt}</Title>
+              <Link href={`/short/${id}`}>
+                <Title level={5} className="mt-0">{prompt}</Title>
+              </Link>
             </div>
-            <a href={scanUrl} target="_blank" rel="noopener noreferrer">
+            <a href={explorerUrl} target="_blank" rel="noopener noreferrer">
               View NFT ↗
             </a>
+            {/* {' '}
+            ·
+            {' '}
+            <a
+              href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(prompt.split(' ').slice(0, 5).join(' '))}... created at https://shorts.wtf%0A&url=${videoUrl}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Share on Twitter
+            </a> */}
           </>
         )}
       />

--- a/components/Home/VideoCard.jsx
+++ b/components/Home/VideoCard.jsx
@@ -6,6 +6,8 @@ import styled from 'styled-components';
 import { getBlockchainShortsAddress } from 'common-util/Contracts';
 import { Video } from 'components/Video';
 import Link from 'next/link';
+import { generateShareUrl, videoShape } from 'components/Short';
+import { TwitterOutlined } from '@ant-design/icons';
 
 const { Title } = Typography;
 
@@ -24,8 +26,11 @@ const EachVideoContainer = styled.div`
   }
 `;
 
-export const VideoCard = ({ id, videoHash, prompt }) => {
+export const VideoCard = ({ video }) => {
+  const { id, videoHash, prompt } = video;
+
   const explorerUrl = getBlockchainShortsAddress(id);
+  const shareUrl = generateShareUrl(video);
 
   return (
     <CustomCard>
@@ -39,22 +44,26 @@ export const VideoCard = ({ id, videoHash, prompt }) => {
           <>
             <div className="mb-8">
               <Link href={`/short/${id}`}>
-                <Title level={5} className="mt-0">{prompt}</Title>
+                <Title level={5} className="mt-0" ellipsis={{ rows: 2, expandable: false }}>{prompt}</Title>
               </Link>
             </div>
-            <a href={explorerUrl} target="_blank" rel="noopener noreferrer">
-              View NFT ↗
-            </a>
-            {/* {' '}
+            <Link href={`/short/${id}`}>
+              View
+            </Link>
+            {' '}
             ·
             {' '}
-            <a
-              href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(prompt.split(' ').slice(0, 5).join(' '))}... created at https://shorts.wtf%0A&url=${videoUrl}`}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Share on Twitter
-            </a> */}
+            <a href={explorerUrl} target="_blank" rel="noopener noreferrer">
+              NFT ↗
+            </a>
+            {' '}
+            ·
+            {' '}
+            <a href={shareUrl} target="_blank" rel="noopener noreferrer">
+              <TwitterOutlined />
+              {' '}
+              Share
+            </a>
           </>
         )}
       />
@@ -63,7 +72,9 @@ export const VideoCard = ({ id, videoHash, prompt }) => {
 };
 
 VideoCard.propTypes = {
-  videoHash: PropTypes.string.isRequired,
-  prompt: PropTypes.string.isRequired,
-  id: PropTypes.number.isRequired,
+  video: PropTypes.shape(videoShape),
+};
+
+VideoCard.defaultProps = {
+  video: null,
 };

--- a/components/Home/VideoList.jsx
+++ b/components/Home/VideoList.jsx
@@ -61,7 +61,7 @@ export const VideoList = () => {
         >
           <Empty
             image={Empty.PRESENTED_IMAGE_SIMPLE}
-            description="No videos to display"
+            description="No shorts to display"
           />
         </div>
       </VideoContainer>

--- a/components/Home/VideoList.jsx
+++ b/components/Home/VideoList.jsx
@@ -82,18 +82,16 @@ export const VideoList = () => {
             style={{ marginTop: '1rem' }}
           />
         )}
-        endMessage={<Divider plain className="mt-48">No more videos to show</Divider>}
+        endMessage={(
+          <Divider plain className="mt-48">
+            No more videos to show
+          </Divider>
+        )}
       >
         <Row gutter={[48, 16]}>
-          {videos.map((video, index) => (
+          {videos.map((video) => (
             <Col xs={24} sm={12} md={12} lg={12} xl={12} key={video.id}>
-              <VideoCard
-                key={index}
-                id={video.id}
-                videoHash={video.video}
-                imageHash={video.image}
-                prompt={video.prompt}
-              />
+              <VideoCard video={video} />
             </Col>
           ))}
         </Row>

--- a/components/Home/VideoList.jsx
+++ b/components/Home/VideoList.jsx
@@ -15,6 +15,7 @@ const VideoContainer = styled.div`
 
 export const VideoList = () => {
   const [loading, setLoading] = useState(false);
+  const [initialLoadComplete, setInitialLoadComplete] = useState(false);
   const [videos, setVideos] = useState([]);
   const [hasMoreVideos, setHasMoreVideos] = useState(true);
   const [pageCount, setPageCount] = useState(0);
@@ -24,7 +25,9 @@ export const VideoList = () => {
       return;
     }
 
-    setLoading(true);
+    if (!initialLoadComplete) {
+      setLoading(true);
+    }
 
     const currentPageCount = pageCount + 1;
     try {
@@ -44,11 +47,12 @@ export const VideoList = () => {
   };
 
   // on initial load
-  useEffect(() => {
-    fetchVideos();
+  useEffect(async () => {
+    await fetchVideos();
+    setInitialLoadComplete(true);
   }, []);
 
-  if (videos?.length === 0) {
+  if (videos?.length === 0 && !loading) {
     return (
       <VideoContainer>
         <div
@@ -74,24 +78,17 @@ export const VideoList = () => {
         dataLength={videos.length}
         next={fetchVideos}
         hasMore={hasMoreVideos}
-        loader={(
-          <Skeleton
-            avatar
-            paragraph={{ rows: 2 }}
-            active
-            style={{ marginTop: '1rem' }}
-          />
-        )}
+        loader={(<Skeleton active />)}
         endMessage={(
           <Divider plain className="mt-48">
-            No more videos to show
+            No more shorts to show
           </Divider>
         )}
       >
         <Row gutter={[48, 16]}>
           {videos.map((video) => (
             <Col xs={24} sm={12} md={12} lg={12} xl={12} key={video.id}>
-              <VideoCard video={video} />
+              {loading ? <Skeleton active /> : <VideoCard video={video} />}
             </Col>
           ))}
         </Row>

--- a/components/Short/index.jsx
+++ b/components/Short/index.jsx
@@ -69,12 +69,12 @@ const Short = ({ video, loading, errorMessage }) => {
               ? `${video.prompt.substring(0, 50)}...`
               : 'Short Video';
             const tweetUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(
-              `${truncatedTitle} created using shorts.wtf\n\nhttps://shorts.wtf/short/${video?.id}`,
+              `"${truncatedTitle}" created using shorts.wtf\n\n🎥 Watch now: https://shorts.wtf/short/${video?.id}`,
             )}`;
             window.open(tweetUrl, '_blank');
           }}
         >
-          Tweet this
+          Share
         </Button>
       </Col>
     </Row>

--- a/components/Short/index.jsx
+++ b/components/Short/index.jsx
@@ -4,7 +4,7 @@ import { FrownTwoTone, TwitterOutlined } from '@ant-design/icons';
 import { COLOR } from '@autonolas/frontend-library';
 import {
   Button,
-  Col, Result, Row, Typography,
+  Col, Result, Row, Skeleton, Typography,
 } from 'antd';
 
 import { Video } from 'components/Video';
@@ -28,54 +28,54 @@ Error.defaultProps = {
 const Short = ({ video, loading, errorMessage }) => {
   const [expanded, setExpanded] = useState(false);
 
-  if (loading) {
-    return <div>Loading...</div>;
-  }
-
-  if (!loading && (errorMessage || !video)) {
+  if (errorMessage) {
     return <Error errorMessage={errorMessage} />;
   }
 
   return (
     <Row align={expanded ? 'top' : 'middle'} gutter={48}>
-      <Col xl={12}>
-        <div style={{ height: '100%', width: '100%' }}>
-          <Video videoHash={video?.video} />
+      <Col md={12}>
+        <div style={{ width: '100%' }}>
+          {loading ? <Skeleton active paragraph={false} /> : <Video videoHash={video?.video} />}
         </div>
       </Col>
-      <Col xl={12}>
-        <Typography.Title
-          level={4}
-          className="mt-0"
-          ellipsis={{
-            rows: 3,
-            expandable: true,
-            onExpand: () => setExpanded(true),
-          }}
-        >
-          {video?.prompt}
-        </Typography.Title>
-        <Typography.Text type="secondary">
-          ID:
-          {' '}
-          {video?.id}
-        </Typography.Text>
-        <br />
-        <br />
-        <Button
-          icon={<TwitterOutlined />}
-          onClick={() => {
-            const truncatedTitle = video?.prompt
-              ? `${video.prompt.substring(0, 50)}...`
-              : 'Short Video';
-            const tweetUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(
-              `"${truncatedTitle}" created using shorts.wtf\n\n🎥 Watch now: https://shorts.wtf/short/${video?.id}`,
-            )}`;
-            window.open(tweetUrl, '_blank');
-          }}
-        >
-          Share
-        </Button>
+      <Col md={12}>
+        {loading ? <Skeleton active /> : (
+          <>
+            <Typography.Title
+              level={4}
+              className="mt-0"
+              ellipsis={{
+                rows: 3,
+                expandable: true,
+                onExpand: () => setExpanded(true),
+              }}
+            >
+              {video?.prompt}
+            </Typography.Title>
+            <Typography.Text type="secondary">
+              ID:
+              {' '}
+              {video?.id}
+            </Typography.Text>
+            <br />
+            <br />
+            <Button
+              icon={<TwitterOutlined />}
+              onClick={() => {
+                const truncatedTitle = video?.prompt
+                  ? `${video.prompt.substring(0, 50)}...`
+                  : 'Short Video';
+                const tweetUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(
+                  `"${truncatedTitle}" created using shorts.wtf\n\n🎥 Watch now: https://shorts.wtf/short/${video?.id}`,
+                )}`;
+                window.open(tweetUrl, '_blank');
+              }}
+            >
+              Share
+            </Button>
+          </>
+        )}
       </Col>
     </Row>
   );

--- a/components/Short/index.jsx
+++ b/components/Short/index.jsx
@@ -1,0 +1,100 @@
+import { useState } from 'react';
+import PropTypes from 'prop-types';
+import { FrownTwoTone, TwitterOutlined } from '@ant-design/icons';
+import { COLOR } from '@autonolas/frontend-library';
+import {
+  Button,
+  Col, Result, Row, Typography,
+} from 'antd';
+
+import { Video } from 'components/Video';
+
+const Error = ({ errorMessage }) => (
+  <Result
+    icon={<FrownTwoTone twoToneColor={COLOR.GREY_1} />}
+    title="Couldn't fetch short"
+    subTitle={JSON.stringify(errorMessage)}
+  />
+);
+
+Error.propTypes = {
+  errorMessage: PropTypes.string,
+};
+
+Error.defaultProps = {
+  errorMessage: '',
+};
+
+const Short = ({ video, loading, errorMessage }) => {
+  const [expanded, setExpanded] = useState(false);
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  if (!loading && (errorMessage || !video)) {
+    return <Error errorMessage={errorMessage} />;
+  }
+
+  return (
+    <Row align={expanded ? 'top' : 'middle'} gutter={48}>
+      <Col xl={12}>
+        <div style={{ height: '100%', width: '100%' }}>
+          <Video videoHash={video?.video} />
+        </div>
+      </Col>
+      <Col xl={12}>
+        <Typography.Title
+          level={4}
+          className="mt-0"
+          ellipsis={{
+            rows: 3,
+            expandable: true,
+            onExpand: () => setExpanded(true),
+          }}
+        >
+          {video?.prompt}
+        </Typography.Title>
+        <Typography.Text type="secondary">
+          ID:
+          {' '}
+          {video?.id}
+        </Typography.Text>
+        <br />
+        <br />
+        <Button
+          icon={<TwitterOutlined />}
+          onClick={() => {
+            const truncatedTitle = video?.prompt
+              ? `${video.prompt.substring(0, 50)}...`
+              : 'Short Video';
+            const tweetUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(
+              `${truncatedTitle} created using shorts.wtf\n\nhttps://shorts.wtf/short/${video?.id}`,
+            )}`;
+            window.open(tweetUrl, '_blank');
+          }}
+        >
+          Tweet this
+        </Button>
+      </Col>
+    </Row>
+  );
+};
+
+Short.propTypes = {
+  video: PropTypes.shape({
+    id: PropTypes.string,
+    video: PropTypes.string,
+    prompt: PropTypes.string,
+  }),
+  loading: PropTypes.bool,
+  errorMessage: PropTypes.string,
+};
+
+Short.defaultProps = {
+  video: null,
+  loading: false,
+  errorMessage: '',
+};
+
+export default Short;

--- a/components/Short/index.jsx
+++ b/components/Short/index.jsx
@@ -8,6 +8,44 @@ import {
 } from 'antd';
 
 import { Video } from 'components/Video';
+import { getBlockchainShortsAddress } from 'common-util/Contracts';
+import { useRouter } from 'next/router';
+
+export const generateShareUrl = (video) => {
+  const truncatedTitle = video?.prompt
+    ? `${video.prompt.substring(0, 50)}...`
+    : 'Short Video';
+  return `https://twitter.com/intent/tweet?text=${encodeURIComponent(
+    `"${truncatedTitle}" created using shorts.wtf\n\n🎥 Watch now: https://shorts.wtf/short/${video?.id}`,
+  )}`;
+};
+
+const ShareButton = ({ video }) => {
+  const handleShare = () => {
+    const tweetUrl = generateShareUrl(video);
+    window.open(tweetUrl, '_blank');
+  };
+
+  return (
+    <Button
+      icon={<TwitterOutlined />}
+      onClick={handleShare}
+    >
+      Share
+    </Button>
+  );
+};
+
+ShareButton.propTypes = {
+  video: PropTypes.shape({
+    id: PropTypes.string,
+    prompt: PropTypes.string,
+  }),
+};
+
+ShareButton.defaultProps = {
+  video: null,
+};
 
 const Error = ({ errorMessage }) => (
   <Result
@@ -27,6 +65,10 @@ Error.defaultProps = {
 
 const Short = ({ video, loading, errorMessage }) => {
   const [expanded, setExpanded] = useState(false);
+  const router = useRouter();
+  const { id } = router.query;
+
+  const explorerUrl = getBlockchainShortsAddress(id);
 
   if (errorMessage) {
     return <Error errorMessage={errorMessage} />;
@@ -57,23 +99,14 @@ const Short = ({ video, loading, errorMessage }) => {
               ID:
               {' '}
               {video?.id}
+              {' '}
+              ·
+              {' '}
+              <a href={explorerUrl} target="_blank" rel="noopener noreferrer">NFT ↗</a>
             </Typography.Text>
             <br />
             <br />
-            <Button
-              icon={<TwitterOutlined />}
-              onClick={() => {
-                const truncatedTitle = video?.prompt
-                  ? `${video.prompt.substring(0, 50)}...`
-                  : 'Short Video';
-                const tweetUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(
-                  `"${truncatedTitle}" created using shorts.wtf\n\n🎥 Watch now: https://shorts.wtf/short/${video?.id}`,
-                )}`;
-                window.open(tweetUrl, '_blank');
-              }}
-            >
-              Share
-            </Button>
+            <ShareButton video={video} />
           </>
         )}
       </Col>
@@ -81,12 +114,14 @@ const Short = ({ video, loading, errorMessage }) => {
   );
 };
 
+export const videoShape = {
+  id: PropTypes.string,
+  video: PropTypes.string,
+  prompt: PropTypes.string,
+};
+
 Short.propTypes = {
-  video: PropTypes.shape({
-    id: PropTypes.string,
-    video: PropTypes.string,
-    prompt: PropTypes.string,
-  }),
+  video: PropTypes.shape(videoShape),
   loading: PropTypes.bool,
   errorMessage: PropTypes.string,
 };

--- a/components/Short/index.jsx
+++ b/components/Short/index.jsx
@@ -3,8 +3,7 @@ import PropTypes from 'prop-types';
 import { FrownTwoTone, TwitterOutlined } from '@ant-design/icons';
 import { COLOR } from '@autonolas/frontend-library';
 import {
-  Button,
-  Col, Result, Row, Skeleton, Typography,
+  Button, Col, Result, Row, Skeleton, Typography,
 } from 'antd';
 
 import { Video } from 'components/Video';
@@ -15,6 +14,7 @@ export const generateShareUrl = (video) => {
   const truncatedTitle = video?.prompt
     ? `${video.prompt.substring(0, 50)}...`
     : 'Short Video';
+
   return `https://twitter.com/intent/tweet?text=${encodeURIComponent(
     `"${truncatedTitle}" created using shorts.wtf\n\n🎥 Watch now: https://shorts.wtf/short/${video?.id}`,
   )}`;
@@ -27,10 +27,7 @@ const ShareButton = ({ video }) => {
   };
 
   return (
-    <Button
-      icon={<TwitterOutlined />}
-      onClick={handleShare}
-    >
+    <Button icon={<TwitterOutlined />} onClick={handleShare}>
       Share
     </Button>
   );
@@ -77,12 +74,14 @@ const Short = ({ video, loading, errorMessage }) => {
   return (
     <Row align={expanded ? 'top' : 'middle'} gutter={48}>
       <Col md={12}>
-        <div style={{ width: '100%' }}>
-          {loading ? <Skeleton active paragraph={false} /> : <Video videoHash={video?.video} />}
+        <div style={{ width: '100%' }} className="mb-12">
+          <Video videoHash={video?.video} />
         </div>
       </Col>
       <Col md={12}>
-        {loading ? <Skeleton active /> : (
+        {loading ? (
+          <Skeleton active />
+        ) : (
           <>
             <Typography.Title
               level={4}
@@ -102,7 +101,9 @@ const Short = ({ video, loading, errorMessage }) => {
               {' '}
               ·
               {' '}
-              <a href={explorerUrl} target="_blank" rel="noopener noreferrer">NFT ↗</a>
+              <a href={explorerUrl} target="_blank" rel="noopener noreferrer">
+                NFT ↗
+              </a>
             </Typography.Text>
             <br />
             <br />

--- a/components/Video/index.jsx
+++ b/components/Video/index.jsx
@@ -1,4 +1,10 @@
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+const StyledVideo = styled.video`
+  width: 100%;
+  aspect-ratio: 1 / 1;
+`;
 
 export const Video = ({ videoHash }) => {
   const videoUrl = `https://${process.env.NEXT_PUBLIC_REGISTRY_URL}${videoHash}`;
@@ -6,10 +12,10 @@ export const Video = ({ videoHash }) => {
   return (
     <>
       {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
-      <video width="100%" style={{ aspectRatio: '1 / 1' }} controls>
+      <StyledVideo controls>
         <source src={videoUrl} type="video/mp4" />
         Your browser does not support the video tag.
-      </video>
+      </StyledVideo>
     </>
   );
 };

--- a/components/Video/index.jsx
+++ b/components/Video/index.jsx
@@ -1,0 +1,19 @@
+import PropTypes from 'prop-types';
+
+export const Video = ({ videoHash }) => {
+  const videoUrl = `https://${process.env.NEXT_PUBLIC_REGISTRY_URL}${videoHash}`;
+
+  return (
+    <>
+      {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+      <video width="100%" height="100%" controls>
+        <source src={videoUrl} type="video/mp4" />
+        Your browser does not support the video tag.
+      </video>
+    </>
+  );
+};
+
+Video.propTypes = {
+  videoHash: PropTypes.string.isRequired,
+};

--- a/components/Video/index.jsx
+++ b/components/Video/index.jsx
@@ -6,7 +6,7 @@ export const Video = ({ videoHash }) => {
   return (
     <>
       {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
-      <video width="100%" height="100%" controls>
+      <video width="100%" style={{ aspectRatio: '1 / 1' }} controls>
         <source src={videoUrl} type="video/mp4" />
         Your browser does not support the video tag.
       </video>

--- a/next.config.js
+++ b/next.config.js
@@ -37,6 +37,15 @@ const nextConfig = {
           },
         ],
       },
+      {
+        source: '/:all*(svg|jpg|jpeg|png|gif|ico|css|js)',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=31536000, must-revalidate',
+          },
+        ],
+      },
     ];
   },
 };

--- a/pages/short/[id].jsx
+++ b/pages/short/[id].jsx
@@ -1,0 +1,84 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import Head from 'next/head';
+
+import Short from 'components/Short';
+import { getAgentURL } from 'common-util/Contracts';
+
+const ShortPage = () => {
+  const router = useRouter();
+  const { id } = router.query;
+  const [loading, setLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [video, setVideo] = useState(null);
+
+  const fetchVideo = async () => {
+    if (loading) {
+      return;
+    }
+
+    setLoading(true);
+
+    try {
+      const agentURL = getAgentURL();
+      const agentResponsesURL = `${agentURL}/responses?id=${id}`;
+      const response = await fetch(agentResponsesURL);
+      const data = await response.json();
+      // TODO: remove [0] once filtering is in place?
+      setVideo(data.data[0]);
+    } catch (error) {
+      setErrorMessage(error);
+      console.error('Failed to fetch video:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchVideo();
+  }, []);
+
+  const truncatedTitle = video?.prompt
+    ? `${video.prompt.substring(0, 50)}...`
+    : 'Short Video';
+  const imageUrl = `https://${process.env.NEXT_PUBLIC_REGISTRY_URL}${video?.image}`;
+
+  return (
+    <>
+      <Head>
+        <title>{`${truncatedTitle} | shorts.wtf`}</title>
+        <meta
+          name="description"
+          content="shorts.wtf is a creative tool for generating AI videos. It aggregates video, music and narration, all in one. Powered by Olas agents. Make your own at https://shorts.wtf."
+        />
+        <meta
+          property="og:title"
+          content={`${truncatedTitle} | created using shorts.wtf`}
+        />
+        <meta
+          property="og:description"
+          content="shorts.wtf is a creative tool for generating AI videos. It aggregates video, music and narration, all in one. Powered by Olas agents. Make your own at https://shorts.wtf."
+        />
+        <meta property="og:image" content={imageUrl} />
+        <meta property="og:url" content={`https://shorts.wtf/short/${id}`} />
+        <meta property="og:type" content="video.movie" />
+        <meta property="og:site_name" content="shorts.wtf" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta
+          name="twitter:title"
+          content={`${truncatedTitle} | created using shorts.wtf`}
+        />
+        <meta
+          name="twitter:description"
+          content="shorts.wtf is a creative tool for generating AI videos. It aggregates video, music and narration, all in one. Powered by Olas agents. Make your own at https://shorts.wtf."
+        />
+        <meta name="twitter:image" content={imageUrl} />
+        <meta name="twitter:site" content="@shorts.wtf" />
+        <meta name="twitter:creator" content="@shorts.wtf" />
+      </Head>
+      <Short video={video} errorMessage={errorMessage} loading={loading} />
+    </>
+  );
+};
+
+export default ShortPage;

--- a/pages/short/[id].jsx
+++ b/pages/short/[id].jsx
@@ -42,39 +42,36 @@ const ShortPage = () => {
     ? `${video.prompt.substring(0, 50)}...`
     : 'Short Video';
   const imageUrl = `https://${process.env.NEXT_PUBLIC_REGISTRY_URL}${video?.image}`;
+  const title = `${truncatedTitle} | Shorts.WTF`;
+  const description = 'Shorts.WTF is a creative tool for generating AI videos. It aggregates video, music and narration, all in one. Powered by Olas agents. Make your own at https://shorts.wtf.';
 
   return (
     <>
       <Head>
-        <title>{`${truncatedTitle} | Shorts.WTF`}</title>
+        {/* <!-- Primary Meta Tags --> */}
+        <title>{title}</title>
+        <meta name="title" content={`${truncatedTitle} | Shorts.WTF`} />
+        <meta name="description" content={description} />
+
+        {/* <!-- Open Graph / Facebook --> */}
+        <meta property="og:type" content="website" />
         <meta
-          name="description"
-          content="Shorts.WTF is a creative tool for generating AI videos. It aggregates video, music and narration, all in one. Powered by Olas agents. Make your own at https://shorts.wtf."
+          property="og:url"
+          content="https://shorts-frontend-git-feat-video-show-page-autonolas.vercel.app"
         />
-        <meta
-          property="og:title"
-          content={`${truncatedTitle} | created using Shorts.WTF`}
-        />
-        <meta
-          property="og:description"
-          content="Shorts.WTF is a creative tool for generating AI videos. It aggregates video, music and narration, all in one. Powered by Olas agents. Make your own at https://shorts.wtf."
-        />
+        <meta property="og:title" content={title} />
+        <meta property="og:description" content={description} />
         <meta property="og:image" content={imageUrl} />
-        <meta property="og:url" content={`https://shorts.wtf/short/${id}`} />
-        <meta property="og:type" content="video.movie" />
-        <meta property="og:site_name" content="Shorts.WTF" />
-        <meta name="twitter:card" content="summary_large_image" />
+
+        {/* <!-- Twitter --> */}
+        <meta property="twitter:card" content="summary_large_image" />
         <meta
-          name="twitter:title"
-          content={`${truncatedTitle} | created using shorts.wtf`}
+          property="twitter:url"
+          content="https://shorts-frontend-git-feat-video-show-page-autonolas.vercel.app"
         />
-        <meta
-          name="twitter:description"
-          content="Shorts.WTF is a creative tool for generating AI videos. It aggregates video, music and narration, all in one. Powered by Olas agents. Make your own at https://shorts.wtf."
-        />
-        <meta name="twitter:image" content={imageUrl} />
-        <meta name="twitter:site" content="@shorts.wtf" />
-        <meta name="twitter:creator" content="@shorts.wtf" />
+        <meta property="twitter:title" content={title} />
+        <meta property="twitter:description" content={description} />
+        <meta property="twitter:image" content={imageUrl} />
       </Head>
       <Short video={video} errorMessage={errorMessage} loading={loading} />
     </>

--- a/pages/short/[id].jsx
+++ b/pages/short/[id].jsx
@@ -46,23 +46,23 @@ const ShortPage = () => {
   return (
     <>
       <Head>
-        <title>{`${truncatedTitle} | shorts.wtf`}</title>
+        <title>{`${truncatedTitle} | Shorts.WTF`}</title>
         <meta
           name="description"
-          content="shorts.wtf is a creative tool for generating AI videos. It aggregates video, music and narration, all in one. Powered by Olas agents. Make your own at https://shorts.wtf."
+          content="Shorts.WTF is a creative tool for generating AI videos. It aggregates video, music and narration, all in one. Powered by Olas agents. Make your own at https://shorts.wtf."
         />
         <meta
           property="og:title"
-          content={`${truncatedTitle} | created using shorts.wtf`}
+          content={`${truncatedTitle} | created using Shorts.WTF`}
         />
         <meta
           property="og:description"
-          content="shorts.wtf is a creative tool for generating AI videos. It aggregates video, music and narration, all in one. Powered by Olas agents. Make your own at https://shorts.wtf."
+          content="Shorts.WTF is a creative tool for generating AI videos. It aggregates video, music and narration, all in one. Powered by Olas agents. Make your own at https://shorts.wtf."
         />
         <meta property="og:image" content={imageUrl} />
         <meta property="og:url" content={`https://shorts.wtf/short/${id}`} />
         <meta property="og:type" content="video.movie" />
-        <meta property="og:site_name" content="shorts.wtf" />
+        <meta property="og:site_name" content="Shorts.WTF" />
         <meta name="twitter:card" content="summary_large_image" />
         <meta
           name="twitter:title"
@@ -70,7 +70,7 @@ const ShortPage = () => {
         />
         <meta
           name="twitter:description"
-          content="shorts.wtf is a creative tool for generating AI videos. It aggregates video, music and narration, all in one. Powered by Olas agents. Make your own at https://shorts.wtf."
+          content="Shorts.WTF is a creative tool for generating AI videos. It aggregates video, music and narration, all in one. Powered by Olas agents. Make your own at https://shorts.wtf."
         />
         <meta name="twitter:image" content={imageUrl} />
         <meta name="twitter:site" content="@shorts.wtf" />


### PR DESCRIPTION
This work adds a dedicated page for each video:
<img width="1496" alt="image" src="https://github.com/valory-xyz/shorts-frontend/assets/66292936/572e9c0a-738b-42f1-adcc-1aa087cd0c8f">

This enables the ability to share a link to the video with an image directly to Twitter:
<img width="631" alt="image" src="https://github.com/valory-xyz/shorts-frontend/assets/66292936/ce7a959c-e53f-4006-9e9e-e699d974d649">
Note: metatags don't work on Vercel preview branches – need to go to prod to test properly.
